### PR TITLE
Fixed highlighting of PHP when mixed with HTML

### DIFF
--- a/scripts/shCore.js
+++ b/scripts/shCore.js
@@ -110,7 +110,7 @@ var sh = {
 		url							: /\w+:\/\/[\w-.\/?%&=:@;]*/g,
 		
 		/** <?= ?> tags. */
-		phpScriptTags 				: { left: /(&lt;|<)\?=?/g, right: /\?(&gt;|>)/g },
+		phpScriptTags 				: { left: /(&lt;|<)\?(?:=|php)?/g, right: /\?(&gt;|>)/g, 'eof_end' : true },
 		
 		/** <%= %> tags. */
 		aspScriptTags				: { left: /(&lt;|<)%=?/g, right: /%(&gt;|>)/g },
@@ -1682,13 +1682,23 @@ sh.Highlighter.prototype = {
 	 */
 	forHtmlScript: function(regexGroup)
 	{
+	
+		var regex = { 'end' : regexGroup.right.source };
+
+		if ( regexGroup.eof_end ) {
+
+			regex.end = "(?:(?:" + regex.end + ")|$)";
+
+		}
+		// if
+		
 		this.htmlScript = {
 			left : { regex: regexGroup.left, css: 'script' },
 			right : { regex: regexGroup.right, css: 'script' },
 			code : new XRegExp(
 				"(?<left>" + regexGroup.left.source + ")" +
 				"(?<code>.*?)" +
-				"(?<right>" + regexGroup.right.source + ")",
+				"(?<right>" + regex.end + ")",
 				"sgi"
 				)
 		};


### PR DESCRIPTION
I noticed that when used with the html-script option, SyntaxHighlighter didn't highlight PHP code between a PHP start tag and the end of the code snippet, when the PHP code goes to the end of the snippet and there is no PHP end tag.  By "the end of the code snippet", I mean what would be EOF if the code were in a file.

The PHP end tag is not required at the end of a file, and omitting it is considered a best practice in files that are not supposed to generate any output (such as a file that defines a class and is meant to be included by other scripts).

Here is a really minimal example of the situation I'm talking about:

```

<div class="whatever">
Blah blah blah.
</div>

<?php

$something = "something";

```

I modified SyntaxHighlighter to highlight PHP code in that situation.  I did that by adding a boolean property, `eof_end`, to `phpScriptTags`, then checking for that in `forHtmlScript()` and adding end of line ("$") as an alternative pattern to the end tag.

I eventually noticed that `phpScriptTags` is also used for the Perl brush, and I don't know if Perl behaves the same as PHP (closing tag at EOF not necessary), so perhaps the information represented by `eof_end` needs to be set in the PHP brush instead. 

Or perhaps PHP and Perl need separate variables to define their start / end tag regexes.  Particularly because I changed `phpScriptTags.left` so that it can match `<?php`.  After I added the `eof_end` functionality, SyntaxHighlighter still wasn't highlighting everything quite right.  When using `<?php` as the start tag and not using a corresponding end tag (because the PHP code goes to EOF), it was highlighting the `<?` but not the `php`.

Personally, I'm not even sure I want it highlighting the PHP start and end tags when mixed with HTML.  It doesn't highlight them when not mixed with HTML.  But if it is going to highlight them, then I want it to apply the same highlighting to start tags that have a corresponding end tag, and start tags that don't have an end tag because the PHP code goes to EOF.

Jesse
