### PR TITLE
Added 'var' keyword for CSharp brush

### DIFF
--- a/scripts/shBrushCSharp.js
+++ b/scripts/shBrushCSharp.js
@@ -11,7 +11,7 @@
 						'interface internal is lock long namespace new null object operator out ' +
 						'override params private protected public readonly ref return sbyte sealed set ' +
 						'short sizeof stackalloc static string struct switch this throw true try ' +
-						'typeof uint ulong unchecked unsafe ushort using virtual void while';
+						'typeof uint ulong unchecked unsafe ushort using virtual void while var';
 
 		function fixComments(match, regexInfo)
 		{


### PR DESCRIPTION
'var' appeared from .NET 3.5 and really widelly spreaded. Without it colored syntax looks weird :)
