### PR TITLE
Include hash/anchor in url regexp

### DIFF
--- a/scripts/shCore.js
+++ b/scripts/shCore.js
@@ -107,7 +107,7 @@ var sh = {
 		multiLineDoubleQuotedString	: new XRegExp('"([^\\\\"]|\\\\.)*"', 'gs'),
 		multiLineSingleQuotedString	: new XRegExp("'([^\\\\']|\\\\.)*'", 'gs'),
 		xmlComments					: /(&lt;|<)!--[\s\S]*?--(&gt;|>)/gm,
-		url							: /\w+:\/\/[\w-.\/?%&=:@;]*/g,
+		url							: /\w+:\/\/[\w-.\/?%&=:@;#]*/g,
 		
 		/** <?= ?> tags. */
 		phpScriptTags 				: { left: /(&lt;|<)\?=?/g, right: /\?(&gt;|>)/g },

--- a/tests/cases/004_url_parsing.html
+++ b/tests/cases/004_url_parsing.html
@@ -5,6 +5,10 @@
 var home = "http://www.alexgorbatchev.come/?test=1&y=2;test/1/2/3;";
 // &lt; http://www.gnu.org/licenses/?test=1&y=2 &gt;.
 
+// Test embedded URLs that include a hash/anchor
+// See github issue #21: https://github.com/alexgorbatchev/SyntaxHighlighter/issues/21#issuecomment-2183732
+var face = "http://example.com/index.php#/other.php"; # i think facebook used to have urls like this
+
 // Test embedded URLs that terminate at a left angle bracket.
 // See bug #28: http://bitbucket.org/alexg/syntaxhighlighter/issue/28/
 "<location>http://www.example.com/song2.mp3</location>";
@@ -29,6 +33,8 @@ queue(function()
 			'http://www.alexgorbatchev.come/?test=1&y=2',
 			'http://www.alexgorbatchev.come/?test=1&y=2;test/1/2/3;',
 			'http://www.gnu.org/licenses/?test=1&y=2',
+			'https://github.com/alexgorbatchev/SyntaxHighlighter/issues/21#issuecomment-2183732',
+			'http://example.com/index.php#/other.php',
 			'http://bitbucket.org/alexg/syntaxhighlighter/issue/28/',
 			'http://www.example.com/song2.mp3'
 		];


### PR DESCRIPTION
This addresses #21.

I implemented a few tests and it seems like it works.
Tests passed in syntaxhighlighter_tests.html on:
- linux firefox 6
- linux chrome 13
- windows ie 7
- windows ie 8

Anything else I should test?
