### PR TITLE
Join lines with '\r\n' to fix copy-paste on IE8

### DIFF
--- a/scripts/shCore.js
+++ b/scripts/shCore.js
@@ -413,7 +413,7 @@ function toArray(source)
  */
 function splitLines(block)
 {
-	return block.split('\n');
+	return block.split(/\r?\n/);
 }
 
 /**


### PR DESCRIPTION
Otherwise windows seems to paste all on one line.
Ddoesn't seem to affect any other browsers.

This addresses #3.
I tested manually in
- linux firefox 6
- linux chrome 11
- windows ie 8

Unfortunately the problem still seems to exist in ie 7.
Not sure what to do about that, yet.

I wasn't sure how to write tests for it, but I'm open to suggestions.
