### PR TITLE
Make diff brush a tiny bit stricter for coloring headers

### DIFF
--- a/scripts/shBrushDiff.js
+++ b/scripts/shBrushDiff.js
@@ -6,8 +6,8 @@
 	function Brush()
 	{
 		this.regexList = [
-			{ regex: /^\+\+\+.*$/gm,		css: 'color2' },
-			{ regex: /^\-\-\-.*$/gm,		css: 'color2' },
+			{ regex: /^\+\+\+\s.*$/gm,		css: 'color2' },
+			{ regex: /^\-\-\-\s.*$/gm,		css: 'color2' },
 			{ regex: /^\s.*$/gm,			css: 'color1' },
 			{ regex: /^@@.*@@$/gm,			css: 'variable' },
 			{ regex: /^\+[^\+]{1}.*$/gm,	css: 'string' },


### PR DESCRIPTION
Instead of coloring a line as a header when it begins with three minuses or three pluses, check that there is a space after the 3rd plus or minus. This is just a tiny bit stricter than before, but will prevent some false positives. This is for issue #38.
