### PR TITLE
Allow perl quote-like operators to be empty

### DIFF
--- a/scripts/shBrushPerl.js
+++ b/scripts/shBrushPerl.js
@@ -48,11 +48,11 @@
 			{ regex: /-?\w+(?=\s*=(>|&gt;))/g,	css: 'string' }, // fat comma
 
 			// is this too much?
-			{ regex: /\bq[qwxr]?\([\s\S]+?\)/g,	css: 'string' }, // quote-like operators ()
-			{ regex: /\bq[qwxr]?\{[\s\S]+?\}/g,	css: 'string' }, // quote-like operators {}
-			{ regex: /\bq[qwxr]?\[[\s\S]+?\]/g,	css: 'string' }, // quote-like operators []
-			{ regex: /\bq[qwxr]?(<|&lt;)[\s\S]+?(>|&gt;)/g,	css: 'string' }, // quote-like operators <>
-			{ regex: /\bq[qwxr]?([^\w({<[])[\s\S]+?\1/g,	css: 'string' }, // quote-like operators non-paired
+			{ regex: /\bq[qwxr]?\([\s\S]*?\)/g,	css: 'string' }, // quote-like operators ()
+			{ regex: /\bq[qwxr]?\{[\s\S]*?\}/g,	css: 'string' }, // quote-like operators {}
+			{ regex: /\bq[qwxr]?\[[\s\S]*?\]/g,	css: 'string' }, // quote-like operators []
+			{ regex: /\bq[qwxr]?(<|&lt;)[\s\S]*?(>|&gt;)/g,	css: 'string' }, // quote-like operators <>
+			{ regex: /\bq[qwxr]?([^\w({<[])[\s\S]*?\1/g,	css: 'string' }, // quote-like operators non-paired
 
 			{ regex: SyntaxHighlighter.regexLib.doubleQuotedString,	css: 'string' },
 			{ regex: SyntaxHighlighter.regexLib.singleQuotedString,	css: 'string' },

--- a/tests/brushes/perl.html
+++ b/tests/brushes/perl.html
@@ -27,6 +27,7 @@ LABEL: {
 
 sub something (;$) { Print @_ } # upper-case P
 *Other::Package::foo = sub { q!bad! };
+my $str = do { my $empty = q{}; $empty .= q'_'; };
 
 print <<HERE;
  doc;


### PR DESCRIPTION
otherwise the color was bleeding to the next matching symbol when the string was empty.
