### PR TITLE
Expanded features relating to finding elements for highlighting.

### DIFF
--- a/scripts/shCore.js
+++ b/scripts/shCore.js
@@ -237,9 +237,10 @@ var sh = {
 	 * @param {Object} globalParams		Optional parameters which override element's 
 	 * 									parameters. Only used if element is specified.
 	 * 
-	 * @param {Object} element	Optional element to highlight. If none is
-	 * 							provided, all elements in the current document 
-	 * 							are returned which qualify.
+	 * @param {Object|string|Array} element	Optional element(s) to highlight. Can be
+	 * 							a DOM node, a tag name (as a string) or an array of
+	 * 							either. If none is provided, all elements in the current
+	 * 							document are returned which qualify.
 	 *
 	 * @return {Array}	Returns list of <code>{ target: DOMElement, params: Object }</code> objects.
 	 */
@@ -250,19 +251,26 @@ var sh = {
 			result = []
 			;
 
-		if (element) {
-			elements = [element];
-		} else if (typeof sh.config.tagName === 'string') {
-			elements = toArray(document.getElementsByTagName(sh.config.tagName));
-		} else {
-			var i;
-			for (i=0; i < sh.config.tagName.length; ++i) {
-				elements.push.apply(
-					elements,
-					toArray(document.getElementsByTagName(sh.config.tagName[i]))
-				);
-			}
+		if (!element) {
+			element = sh.config.tagName;
 		}
+
+		if (typeof element === 'string') {
+			elements = toArray(document.getElementsByTagName(element));
+		} else if (element instanceof Array) {
+			var i;
+			for (i=0; i < element.length; ++i) {
+				if (typeof element[i] === 'string') {
+					element[i] = toArray(document.getElementsByTagName(element[i]));
+					elements.push.apply(elements, element[i]);
+				} else {
+					elements.push(element[i]);
+				}
+			}
+		} else {
+			elements = [element];
+		}
+
 		// support for <SCRIPT TYPE="syntaxhighlighter" /> feature
 		if (conf.useScriptTags)
 			elements = elements.concat(getSyntaxHighlighterScriptTags());


### PR DESCRIPTION
I've got two new features, if you're interested. 

The first allows SyntaxHighlighter to find multiple element types. Instead of a single tag name, the `tagName` configuration option can be an array of tag names, in which case `findElements` gets all the named elements. I left the config option singular so as not to affect sites that customize it. The default `tagName` option is updated to include `<code>` elements so developers can write more semantic documents yet still get highlighting in JS enabled browsers, all without impacting existing sites that use SyntaxHighlighter.

The second expands `findElements` to accept DOM nodes, tag names or an array of both as its `element` parameter. This way, a developer can specify multiple elements to highlight in a single call to `highlight`.

```
var someElt = document.getElementById('Foo');
SyntaxHighlighter.highlight({}, ['pre', 'code', someElt]);
```

Do these updates interest you? Do they need any other work before they can be merged into the main repo?
