### PR TITLE
Only match __END__ tokens at the beginning of a line

### DIFF
--- a/scripts/shBrushPerl.js
+++ b/scripts/shBrushPerl.js
@@ -58,7 +58,7 @@
 			{ regex: SyntaxHighlighter.regexLib.singleQuotedString,	css: 'string' },
 			// currently ignoring single quote package separator and utf8 names
 			{ regex: /(?:&amp;|[$@%*]|\$#)[a-zA-Z_](\w+|::)*/g,   		css: 'variable' },
-			{ regex: /\b__(?:END|DATA)__\b[\s\S]*$/g,				css: 'comments' },
+			{ regex: /(^|\n)\s*__(?:END|DATA)__\b[\s\S]*$/g,		css: 'comments' },
 			{ regex: /(^|\n)=\w[\s\S]*?(\n=cut\s*\n|$)/g,				css: 'comments' },		// pod
 			{ regex: new RegExp(this.getKeywords(funcs), 'gm'),		css: 'functions' },
 			{ regex: new RegExp(this.getKeywords(keywords), 'gm'),	css: 'keyword' }

--- a/tests/brushes/perl.html
+++ b/tests/brushes/perl.html
@@ -40,7 +40,11 @@ Load(&lt;&lt;'...'); # YAML heredoc
 type: yaml
 ...
 
-print 1; __END__
+print "quoted __END__ marker";
+
+__END__LIKE_block
+
+__END__
 print 2;  # won't print; after script
 __DATA__
 fake file handle


### PR DESCRIPTION
It's not perfect, but it will likely be correct more often.

fixes gh-92.
