### PR TITLE
In shAutoloader.js: Only load the script which is not loaded

### DIFF
--- a/scripts/shAutoloader.js
+++ b/scripts/shAutoloader.js
@@ -68,9 +68,13 @@ sh.autoloader = function()
 		
 		if (!url)
 			continue;
-		
-		scripts[url] = false;
-		loadScript(url);
+
+		// Only load the script which is not loaded
+		if(scripts[url] == undefined)
+		{
+			scripts[url] = false;
+			loadScript(url);
+		}
 	}
 	
 	function loadScript(url)


### PR DESCRIPTION
Hello,
I found that if I write the same brush tags in my post, the autoloader will load several duplicate scripts.
http://i.minus.com/iZnQUf2grvljw.png

So I add a check in the code.
Now only with one request.
http://i.minus.com/iuYtg7MbOlxyR.png
