### PR TITLE
shAutoloader.js duplicate loading and html-script support.

### DIFF
--- a/scripts/shAutoloader.js
+++ b/scripts/shAutoloader.js
@@ -6,7 +6,7 @@ var sh = SyntaxHighlighter;
  * Provides functionality to dynamically load only the brushes that a needed to render the current page.
  *
  * There are two syntaxes that autoload understands. For example:
- * 
+ *
  * SyntaxHighlighter.autoloader(
  *     [ 'applescript',          'Scripts/shBrushAppleScript.js' ],
  *     [ 'actionscript3', 'as3', 'Scripts/shBrushAS3.js' ]
@@ -30,19 +30,19 @@ sh.autoloader = function()
 		allParams = null,
 		i
 		;
-		
+
 	SyntaxHighlighter.all = function(params)
 	{
 		allParams = params;
 		allCalled = true;
 	};
-	
+
 	function addBrush(aliases, url)
 	{
 		for (var i = 0; i < aliases.length; i++)
 			brushes[aliases[i]] = url;
 	};
-	
+
 	function getAliases(item)
 	{
 		return item.pop
@@ -50,35 +50,43 @@ sh.autoloader = function()
 			: item.split(/\s+/)
 			;
 	}
-	
+
 	// create table of aliases and script urls
 	for (i = 0; i < list.length; i++)
 	{
 		var aliases = getAliases(list[i]),
 			url = aliases.pop()
 			;
-			
+
 		addBrush(aliases, url);
 	}
-	
+
 	// dynamically add <script /> tags to the document body
 	for (i = 0; i < elements.length; i++)
 	{
 		var url = brushes[elements[i].params.brush];
-		
-		if (!url)
-			continue;
-		
-		scripts[url] = false;
-		loadScript(url);
+
+		if(url && scripts[url] === undefined)
+		{
+			if(elements[i].params['html-script'] === 'true')
+			{
+				if(scripts[brushes['xml']] === undefined) {
+					loadScript(brushes['xml']);
+					scripts[url] = false;
+				}
+			}
+
+			scripts[url] = false;
+			loadScript(url);
+		}
 	}
-	
+
 	function loadScript(url)
 	{
 		var script = document.createElement('script'),
 			done = false
 			;
-		
+
 		script.src = url;
 		script.type = 'text/javascript';
 		script.language = 'javascript';
@@ -89,23 +97,23 @@ sh.autoloader = function()
 				done = true;
 				scripts[url] = true;
 				checkAll();
-				
+
 				// Handle memory leak in IE
 				script.onload = script.onreadystatechange = null;
 				script.parentNode.removeChild(script);
 			}
 		};
-		
+
 		// sync way of adding script tags to the page
 		document.body.appendChild(script);
 	};
-	
+
 	function checkAll()
 	{
 		for(var url in scripts)
 			if (scripts[url] == false)
 				return;
-		
+
 		if (allCalled)
 			SyntaxHighlighter.highlight(allParams);
 	};


### PR DESCRIPTION
I made a few changes to the autoloader to address some issues that I was having. Firstly it would load duplicate brushes if called more than once. Secondly, it did not support the html-script parameter and caused an error unless you manually load the xml brush prior to the brush you want to use in the mixed code example. It will now properly load the xml brush automatically if needed, unless it has already been loaded.

Changes
- prevent the loading of duplicate brush files.
- add support for the html-script parameter. 
