### PR TITLE
Code block generated from md file support

### DIFF
--- a/scripts/shCore.js
+++ b/scripts/shCore.js
@@ -1089,7 +1089,7 @@ function stripCData(original)
 /**
  * Strips <code></code> from content.
  * @param {String} original	Input code.
- * @return {String} Returns code without leading <![CDATA[]]> tags.
+ * @return {String} Returns code without leading <code></code> tags.
  */
 function stripCodeTags(original)
 {


### PR DESCRIPTION
# issue 

Markdown-ed document codeblock is represented as:

```
var something_code_block
```

Actually, this generates below:

```
<pre><code>var something_code_block</code></pre>
```

when I paste 

```
<pre class="brush: js"><code>var something_code_block</code></pre>
```

into my Google Blogger, results like below:

```
<code>var something_code_block</code>
```
# I changed

when config.useMdPreCode === true, then strip leading &lt;code&gt;&lt;/code&gt; from &lt;pre&gt;&lt;/pre&gt; block.
