### PR TITLE
Support for multiline SQL comments

### DIFF
--- a/scripts/shBrushSql.js
+++ b/scripts/shBrushSql.js
@@ -31,6 +31,7 @@
 
 		this.regexList = [
 			{ regex: /--(.*)$/gm,												css: 'comments' },			// one line and multiline comments
+			{ regex: /\/\*([^\*][\s\S]*)?\*\//gm,
 			{ regex: SyntaxHighlighter.regexLib.multiLineDoubleQuotedString,	css: 'string' },			// double quoted strings
 			{ regex: SyntaxHighlighter.regexLib.multiLineSingleQuotedString,	css: 'string' },			// single quoted strings
 			{ regex: new RegExp(this.getKeywords(funcs), 'gmi'),				css: 'color2' },			// functions


### PR DESCRIPTION
In SQL there is also the option for multiline SQL comments. This pull request adds this to the SQL brush. The regex is copied from the Java brush, where are also multiline comments with the same syntax.

/\* Retrieve all companies and
corresponding country outside of USA */

SELECT Company, Country   -- if we retrieve from CustomerContact, we need a count(*)
FROM Customers       -- or we can retrieve from CustomerContact
WHERE Country <> 'USA'

http://docs.oracle.com/cd/B28359_01/appdev.111/b28370/comment.htm

Kind regards
Holger
