### PR TITLE
Fix syntax highlighting for adjacent pod blocks

### DIFF
--- a/scripts/shBrushPerl.js
+++ b/scripts/shBrushPerl.js
@@ -59,7 +59,10 @@
 			// currently ignoring single quote package separator and utf8 names
 			{ regex: /(?:&amp;|[$@%*]|\$#)[a-zA-Z_](\w+|::)*/g,   		css: 'variable' },
 			{ regex: /\b__(?:END|DATA)__\b[\s\S]*$/g,				css: 'comments' },
-			{ regex: /(^|\n)=\w[\s\S]*?(\n=cut\s*\n|$)/g,				css: 'comments' },		// pod
+
+			// don't capture the newline after =cut so that =cut\n\n=head1 will start a new pod section
+			{ regex: /(^|\n)=\w[\s\S]*?(\n=cut\s*(?=\n)|$)/g,		css: 'comments' },		// pod
+
 			{ regex: new RegExp(this.getKeywords(funcs), 'gm'),		css: 'functions' },
 			{ regex: new RegExp(this.getKeywords(keywords), 'gm'),	css: 'keyword' }
 		];

--- a/tests/brushes/perl.html
+++ b/tests/brushes/perl.html
@@ -48,6 +48,18 @@ fake file handle
 <script class="brush: perl;" type="syntaxhighlighter">
 # comment
 
+=head1 Some Pod
+
+Don't let a =cut break the next =pod
+
+=cut
+
+=head2 More pod
+
+Ensure the above =cut doesn't break this
+
+=cut
+
 =head1 Foo
 
 No 'cut' block, it just ends.


### PR DESCRIPTION
Don't capture the newline after `=cut`
so that `=cut\n\n=head1` will start a new pod section.

Otherwise the second pod block isn't getting highlighted as pod.
