### PR TITLE
Correctly highlight dereferenced vars (double sigils)

### DIFF
--- a/scripts/shBrushPerl.js
+++ b/scripts/shBrushPerl.js
@@ -57,7 +57,7 @@
 			{ regex: SyntaxHighlighter.regexLib.doubleQuotedString,	css: 'string' },
 			{ regex: SyntaxHighlighter.regexLib.singleQuotedString,	css: 'string' },
 			// currently ignoring single quote package separator and utf8 names
-			{ regex: /(?:&amp;|[$@%*]|\$#)[a-zA-Z_](\w+|::)*/g,   		css: 'variable' },
+			{ regex: /(?:&amp;|[$@%*]|\$#)\$?[a-zA-Z_](\w+|::)*/g,   		css: 'variable' },
 			{ regex: /\b__(?:END|DATA)__\b[\s\S]*$/g,				css: 'comments' },
 			{ regex: /(^|\n)=\w[\s\S]*?(\n=cut\s*\n|$)/g,				css: 'comments' },		// pod
 			{ regex: new RegExp(this.getKeywords(funcs), 'gm'),		css: 'functions' },

--- a/tests/brushes/perl.html
+++ b/tests/brushes/perl.html
@@ -10,6 +10,8 @@ my %hash = %Package::Stash::;
 our @array = 1 .. 3;
 print $#array, $array[0];
 
+do { my $arr = [ 0, 1 ]; print $#$arr, @$arr };
+
 local $ENV{FOO} = qq[BAR $foo];
 call(func => "args", opt => q#val#, code => \&amp;baz);
 


### PR DESCRIPTION
perl's well-known sigils can also be used on a scalar reference which basically puts the various characters in front of a dollar sign.
