### PR TITLE
Added missing reserved keywords for JavaScript

### DIFF
--- a/scripts/shBrushJScript.js
+++ b/scripts/shBrushJScript.js
@@ -5,12 +5,12 @@
 
 	function Brush()
 	{
-		var keywords =	'break case catch continue ' +
-						'default delete do else false  ' +
-						'for function if in instanceof ' +
-						'new null return super switch ' +
-						'this throw true try typeof var while with'
-						;
+		var keywords =	'break case catch class continue ' +
+				'default delete do else enum export extends false  ' +
+				'for function if implements import in instanceof ' +
+				'interface let new null package private protected ' +
+				'static return super switch ' +
+				'this throw true try typeof var while with yield';
 
 		var r = SyntaxHighlighter.regexLib;
 		


### PR DESCRIPTION
EcmaScript has evolved and now more keywords are reserved
(see https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Reserved_Words )
