### PR TITLE
Important fix for critical bug introduced in SQL syntax highlighting in implementation for #190

### DIFF
--- a/scripts/shBrushSql.js
+++ b/scripts/shBrushSql.js
@@ -30,13 +30,13 @@
 		var operators =	'all and any between cross in join like not null or outer some';
 
 		this.regexList = [
-			{ regex: /--(.*)$/gm,												css: 'comments' },			// one line and multiline comments
-			{ regex: /\/\*([^\*][\s\S]*?)?\*\//gm,
-			{ regex: SyntaxHighlighter.regexLib.multiLineDoubleQuotedString,	css: 'string' },			// double quoted strings
-			{ regex: SyntaxHighlighter.regexLib.multiLineSingleQuotedString,	css: 'string' },			// single quoted strings
-			{ regex: new RegExp(this.getKeywords(funcs), 'gmi'),				css: 'color2' },			// functions
-			{ regex: new RegExp(this.getKeywords(operators), 'gmi'),			css: 'color1' },			// operators and such
-			{ regex: new RegExp(this.getKeywords(keywords), 'gmi'),				css: 'keyword' }			// keyword
+			{ regex: /--(.*)$/gm,                                               css: 'comments' },   // one line comments
+			{ regex: /\/\*([^\*][\s\S]*?)?\*\//gm,                              css: 'comments' },   // multi line comments
+			{ regex: SyntaxHighlighter.regexLib.multiLineDoubleQuotedString,    css: 'string' },     // double quoted strings
+			{ regex: SyntaxHighlighter.regexLib.multiLineSingleQuotedString,    css: 'string' },     // single quoted strings
+			{ regex: new RegExp(this.getKeywords(funcs), 'gmi'),                css: 'color2' },     // functions
+			{ regex: new RegExp(this.getKeywords(operators), 'gmi'),            css: 'color1' },     // operators and such
+			{ regex: new RegExp(this.getKeywords(keywords), 'gmi'),             css: 'keyword' }     // keyword
 			];
 	};
 


### PR DESCRIPTION
For the changes for #190 I have done a major bug when copying the regex for multi line comments in SQL from Java syntax. I only copied the regex without assigning it to 'comment', so the hole JavaScript syntax of the SQL highlighting definition is now broken.

Please merge this pull request into master to get a bugfix. Thank you and sorry for introducing this trouble!

Cheers
Holger
