### PR TITLE
Include some additional aliases for JS, XML and Cpp

### DIFF
--- a/scripts/shBrushCpp.js
+++ b/scripts/shBrushCpp.js
@@ -72,7 +72,7 @@
 	};
 
 	Brush.prototype	= new SyntaxHighlighter.Highlighter();
-	Brush.aliases	= ['cpp', 'c'];
+	Brush.aliases	= ['cpp', 'cc', 'c++', 'c', 'h', 'hpp', 'h++'];
 
 	SyntaxHighlighter.brushes.Cpp = Brush;
 

--- a/scripts/shBrushJScript.js
+++ b/scripts/shBrushJScript.js
@@ -27,7 +27,7 @@
 	};
 
 	Brush.prototype	= new SyntaxHighlighter.Highlighter();
-	Brush.aliases	= ['js', 'jscript', 'javascript'];
+	Brush.aliases	= ['js', 'jscript', 'javascript', 'json'];
 
 	SyntaxHighlighter.brushes.JScript = Brush;
 

--- a/scripts/shBrushXml.js
+++ b/scripts/shBrushXml.js
@@ -9,7 +9,7 @@
 		{
 			var constructor = SyntaxHighlighter.Match,
 				code = match[0],
-				tag = new XRegExp('(&lt;|<)[\\s\\/\\?]*(?<name>[:\\w-\\.]+)', 'xg').exec(code),
+				tag = new XRegExp('(&lt;|<)[\\s\\/\\?!]*(?<name>[:\\w-\\.]+)', 'xg').exec(code),
 				result = []
 				;
 		
@@ -39,12 +39,12 @@
 		this.regexList = [
 			{ regex: new XRegExp('(\\&lt;|<)\\!\\[[\\w\\s]*?\\[(.|\\s)*?\\]\\](\\&gt;|>)', 'gm'),			css: 'color2' },	// <![ ... [ ... ]]>
 			{ regex: SyntaxHighlighter.regexLib.xmlComments,												css: 'comments' },	// <!-- ... -->
-			{ regex: new XRegExp('(&lt;|<)[\\s\\/\\?]*(\\w+)(?<attributes>.*?)[\\s\\/\\?]*(&gt;|>)', 'sg'), func: process }
+			{ regex: new XRegExp('(&lt;|<)[\\s\\/\\?!]*(\\w+)(?<attributes>.*?)[\\s\\/\\?]*(&gt;|>)', 'sg'), func: process }
 		];
 	};
 
 	Brush.prototype	= new SyntaxHighlighter.Highlighter();
-	Brush.aliases	= ['xml', 'xhtml', 'xslt', 'html'];
+	Brush.aliases	= ['xml', 'xhtml', 'xslt', 'html', 'plist'];
 
 	SyntaxHighlighter.brushes.Xml = Brush;
 


### PR DESCRIPTION
This pull request includes support for:
  aliases: 'cc', 'c++', 'c', 'h', 'hpp', 'h++' in the Cpp brush type
  aliases: 'json' in the JScript brush type
  aliases: 'plist' in the Xml brush type

It also supports tags starting with <! to allow for doctype tags to be highlighted in the Xml brush type.
