### PR TITLE
Add option to put anchors on lines

### DIFF
--- a/scripts/shCore.js
+++ b/scripts/shCore.js
@@ -61,7 +61,15 @@ var sh = {
 
 		'unindent' : true,
 		
-		'html-script' : false
+		'html-script' : false,
+
+		/** 
+		 * If enabled, adds lineno<linenumber> anchors to all lines.
+		 * Intended to be used when syntaxHighlighting a whole file
+		 * You can then link with something like this: ref="somefile.html#lineno42".
+		 * In the SyntaxHighligthed page, you must write the body.onLoad handler something this:
+		 * onLoad="SyntaxHighlighter.highlight(); location.hash=location.hash;" */
+		'lineno-anchors' : false
 	},
 	
 	config : {
@@ -1396,8 +1404,11 @@ sh.Highlighter.prototype = {
 		
 		if (lineNumber == 0)
 			classes.push('break');
-			
-		return '<div class="' + classes.join(' ') + '">' + code + '</div>';
+		if (this.getParam('lineno-anchors')) {
+			return '<div class="' + classes.join(' ') + '"><a id="lineno' + lineNumber + '"></a>' + code + '</div>';               
+		} else {
+			return '<div class="' + classes.join(' ') + '">' + code + '</div>';
+		}
 	},
 	
 	/**


### PR DESCRIPTION
Added option to put anchors on lines: 'lineno-anchors', with default 
value false.

If enabled, adds lineno<linenumber> anchors to all lines.

This is intended to be used when syntaxHighlighting a whole file, or
with a most one source fragment on the page.

It can then be used with something like this:
ref="somefile.html#lineno42".

In the SyntaxHighlighted page, you must write the body.onLoad
handler something this:
onLoad="SyntaxHighlighter.highlight(); location.hash=location.hash;"
