### PR TITLE
Fixed theme bug. 

### DIFF
--- a/src/sass/_theme_template.scss
+++ b/src/sass/_theme_template.scss
@@ -57,6 +57,15 @@ $caption_color:					$code_plain !default;
 		caption {
 			color: $caption_color !important;
 		}
+		
+		td.code {
+			.container {
+				textarea {
+					background: $background;
+					color: $code_plain;
+				} 
+			}
+		} 
 	}
 	
 	// Add border to the lines


### PR DESCRIPTION
When double clicking the background always was white with black text regardless what the $background and $code_plain was set to.
