### PR TITLE
type "syntaxhighlighter" is missing subtype

### DIFF
--- a/src/js/shCore.js
+++ b/src/js/shCore.js
@@ -1064,7 +1064,7 @@ function getSyntaxHighlighterScriptTags()
 		;
 
 	for (var i = 0; i < tags.length; i++)
-		if (tags[i].type == 'syntaxhighlighter')
+		if (tags[i].type == 'text/syntaxhighlighter')
 			result.push(tags[i]);
 
 	return result;


### PR DESCRIPTION
W3C validator says "Bad value syntaxhighlighter for attribute type on element script: Subtype missing.".

Will have to change <script type="syntaxhighlighter" ... > to <script type="text/syntaxhighlighter" ... > also.