### PR TITLE
change none-breake-space "c2 a0" to space "20"

### DIFF
--- a/src/js/shCore.js
+++ b/src/js/shCore.js
@@ -1134,11 +1134,12 @@ function quickCodeHandler(e)
 	for (var i = 0; i < lines.length; i++)
 		code.push(lines[i].innerText || lines[i].textContent);
 
+	// Change none-breake-space "hex : c2 a0" to space "hex : 20".
+	for (var i = 0; i < code.length; i++)
+		code[i] = code[i].replace(/\u00a0/g, ' ');
+
 	// using \r instead of \r or \r\n makes this work equally well on IE, FF and Webkit
 	code = code.join('\r');
-
-    // For Webkit browsers, replace nbsp with a breaking space
-    code = code.replace(/\u00a0/g, " ");
 
 	// inject <textarea/> tag
 	textarea.appendChild(document.createTextNode(code));


### PR DESCRIPTION
I has some problems when copying from Opera, Safari og Chrome with charters called none-break-space that looks like space charter but are not the same.

Might be that (space : '&nbsp;',) gets turned into a none-break-space inside the browser instead of a space.
