### PR TITLE
Add missing css keywords/values in shBrushCss.js

### DIFF
--- a/src/js/shBrushCss.js
+++ b/src/js/shBrushCss.js
@@ -15,35 +15,36 @@
 			return '\\b' + str.replace(/ /g, '(?!-)(?!:)\\b|\\b()') + '\:\\b';
 		};
 
-		var keywords =	'ascent azimuth background-attachment background-color background-image background-position ' +
+		var keywords =	'animation-delay animation-direction animation-duration animation-iteration-count animation-name align-content ' +
+						'ascent azimuth background-attachment background-size background-clip background-color background-image background-position ' +
 						'background-repeat background baseline bbox border-collapse border-color border-spacing border-style border-top ' +
 						'border-right border-bottom border-left border-top-color border-right-color border-bottom-color border-left-color ' +
 						'border-top-style border-right-style border-bottom-style border-left-style border-top-width border-right-width ' +
-						'border-bottom-width border-left-width border-width border bottom cap-height caption-side centerline clear clip color ' +
+						'border-bottom-width border-left-width border-width border bottom box-shadow box-sizing cap-height caption-side centerline clear clip color ' +
 						'content counter-increment counter-reset cue-after cue-before cue cursor definition-src descent direction display ' +
-						'elevation empty-cells float font-size-adjust font-family font-size font-stretch font-style font-variant font-weight font ' +
+						'elevation empty-cells flex-flow float font-size-adjust font-family font-size font-stretch font-style font-variant font-weight font ' +
 						'height left letter-spacing line-height list-style-image list-style-position list-style-type list-style margin-top ' +
-						'margin-right margin-bottom margin-left margin marker-offset marks mathline max-height max-width min-height min-width orphans ' +
-						'outline-color outline-style outline-width outline overflow padding-top padding-right padding-bottom padding-left padding page ' +
+						'margin-right margin-bottom margin-left margin marker-offset marks mathline max-height max-width min-height min-width opacity orphans ' +
+						'outline-color outline-style outline-width outline overflow overflow-x padding-top padding-right padding-bottom padding-left padding page ' +
 						'page-break-after page-break-before page-break-inside pause pause-after pause-before pitch pitch-range play-during position ' +
-						'quotes right richness size slope src speak-header speak-numeral speak-punctuation speak speech-rate stemh stemv stress ' +
-						'table-layout text-align top text-decoration text-indent text-shadow text-transform unicode-bidi unicode-range units-per-em ' +
+						'quotes resize right richness size slope src speak-header speak-numeral speak-punctuation speak speech-rate stemh stemv stress ' +
+						'table-layout text-align top text-decoration text-indent text-shadow text-transform transform transition unicode-bidi unicode-range units-per-em ' +
 						'vertical-align visibility voice-family volume white-space widows width widths word-spacing x-height z-index';
 
 		var values =	'above absolute all always aqua armenian attr aural auto avoid baseline behind below bidi-override black blink block blue bold bolder '+
-						'both bottom braille capitalize caption center center-left center-right circle close-quote code collapse compact condensed '+
-						'continuous counter counters crop cross crosshair cursive dashed decimal decimal-leading-zero default digits disc dotted double '+
-						'embed embossed e-resize expanded extra-condensed extra-expanded fantasy far-left far-right fast faster fixed format fuchsia '+
-						'gray green groove handheld hebrew help hidden hide high higher icon inline-table inline inset inside invert italic '+
-						'justify landscape large larger left-side left leftwards level lighter lime line-through list-item local loud lower-alpha '+
+						'border-box both bottom braille capitalize caption center center-left center-right circle close-quote code collapse compact condensed '+
+						'continuous content-box counter counters cover crop cross crosshair cursive dashed decimal decimal-leading-zero default digits disc dotted double '+
+						'embed embossed e-resize expanded extra-condensed extra-expanded fantasy far-left far-right fast faster fixed flex format fuchsia '+
+						'gray green groove handheld hebrew help hidden hide high higher icon infinite inherit inline-block inline-table inline inset inside invert italic '+
+						'justify landscape large larger left-side left leftwards level lighter lime linear linear-gradient line-through list-item local loud lower-alpha '+
 						'lowercase lower-greek lower-latin lower-roman lower low ltr marker maroon medium message-box middle mix move narrower '+
 						'navy ne-resize no-close-quote none no-open-quote no-repeat normal nowrap n-resize nw-resize oblique olive once open-quote outset '+
-						'outside overline pointer portrait pre print projection purple red relative repeat repeat-x repeat-y rgb ridge right right-side '+
-						'rightwards rtl run-in screen scroll semi-condensed semi-expanded separate se-resize show silent silver slower slow '+
-						'small small-caps small-caption smaller soft solid speech spell-out square s-resize static status-bar sub super sw-resize '+
-						'table-caption table-cell table-column table-column-group table-footer-group table-header-group table-row table-row-group teal '+
-						'text-bottom text-top thick thin top transparent tty tv ultra-condensed ultra-expanded underline upper-alpha uppercase upper-latin '+
-						'upper-roman url visible wait white wider w-resize x-fast x-high x-large x-loud x-low x-slow x-small x-soft xx-large xx-small yellow';
+						'outside overline pointer portrait pre print projection purple red relative repeat repeat-x repeat-y rgb rgba ridge right right-side '+
+						'rightwards rotate row rtl run-in scale screen scroll semi-condensed semi-expanded separate se-resize show silent silver skewX skewY slower slow '+
+						'small small-caps small-caption smaller space-around soft solid speech spell-out square s-resize static status-bar sub super sw-resize '+
+						'table table-caption table-cell table-column table-column-group table-footer-group table-header-group table-row table-row-group teal '+
+						'text-bottom text-top thick thin top translate translateX translateY transparent tty tv ultra-condensed ultra-expanded underline upper-alpha uppercase upper-latin '+
+						'upper-roman url visible wait webkit-box white wider wrap w-resize x-fast x-high x-large x-loud x-low x-slow x-small x-soft xx-large xx-small yellow';
 
 		var fonts =		'[mM]onospace [tT]ahoma [vV]erdana [aA]rial [hH]elvetica [sS]ans-serif [sS]erif [cC]ourier mono sans serif';
 	


### PR DESCRIPTION
New keywords : `animation-delay` `animation-direction` `animation-duration` `animation-iteration-count` `animation-name` `background-size` `background-clip` `box-sizing` `overflow-x` `box-shadow` `opacity` `flex-flow` `resize` `align-content` `transform` `transition`

New values : `inherit` `content-box` `border-box` `table` `flex` `row` `wrap` `space-around` `infinite` `linear` `linear-gradient` `rgba` `webkit-box` `scale` `rotate` `translate` `translateX` `translateY` `skewX` `skewY`

Don't know how to add `@keyframes` and prefixes like `-webkit-`, `-moz-`, etc... :(
