### PR TITLE
Allow for asterisks after start of block comment

### DIFF
--- a/src/brushes/sql.js
+++ b/src/brushes/sql.js
@@ -31,7 +31,7 @@
 
 		this.regexList = [
 			{ regex: /--(.*)$/gm,                                               css: 'comments' },   // one line comments
-			{ regex: /\/\*([^\*][\s\S]*?)?\*\//gm,                              css: 'comments' },   // multi line comments
+			{ regex: /\/\*([\s\S]*?)?\*\//gm,                              	    css: 'comments' },   // multi line comments
 			{ regex: SyntaxHighlighter.regexLib.multiLineDoubleQuotedString,    css: 'string' },     // double quoted strings
 			{ regex: SyntaxHighlighter.regexLib.multiLineSingleQuotedString,    css: 'string' },     // single quoted strings
 			{ regex: new RegExp(this.getKeywords(funcs), 'gmi'),                css: 'color2' },     // functions


### PR DESCRIPTION
Multi-line sql comments with more than one asterisk were not being properly formatted as the regex says there cannot be an asterisk following the start of block comment /*

The following would be formatted like normal sql statements and not as a comment:
/********
select 'example'
*/