### PR TITLE
Add F# Brush

### DIFF
--- a/src/js/shBrushFSharp.js
+++ b/src/js/shBrushFSharp.js
@@ -1,0 +1,65 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+;(function()
+{
+	// CommonJS
+	typeof(require) != 'undefined' ? SyntaxHighlighter = require('shCore').SyntaxHighlighter : null;
+
+	function Brush()
+	{
+		var keywords =	'abstract and as assert begin base bool break byte case catch char checked class const ' +
+						'continue decimal default delegate do done downcast downto double else elif end enum event explicit ' +
+						'exception extern false finally fixed float for foreach fun function global get goto if implicit in inherit inline int ' +
+						'interface internal is lazy let let! lock long match member module mutable namespace new not null of open or object operator out ' +
+						'override params private protected public readonly rec ref return return! select sbyte sealed set ' +
+						'short sizeof stackalloc static string struct switch then to this throw true try ' +
+						'type typeof uint ulong unchecked upcast unsafe ushort use use! val using virtual void while when with yield yield!';
+
+		function fixComments(match, regexInfo)
+		{
+			var css = (match[0].indexOf("///") == 0)
+				? 'color1'
+				: 'comments'
+				;
+			
+			return [new SyntaxHighlighter.Match(match[0], match.index, css)];
+		}
+
+		this.regexList = [
+			{ regex: SyntaxHighlighter.regexLib.singleLineCComments,	func : fixComments },		// one line comments
+			{ regex: SyntaxHighlighter.regexLib.multiLineCComments,		css: 'comments' },			// multiline comments
+			{ regex: /@"(?:[^"]|"")*"/g,								css: 'string' },			// @-quoted strings
+			{ regex: SyntaxHighlighter.regexLib.doubleQuotedString,		css: 'string' },			// strings
+			{ regex: SyntaxHighlighter.regexLib.singleQuotedString,		css: 'string' },			// strings
+			{ regex: /^\s*#.*/gm,										css: 'preprocessor' },		// preprocessor tags like #region and #endregion
+			{ regex: new RegExp(this.getKeywords(keywords), 'gm'),		css: 'keyword' },			// c# keyword
+			{ regex: /\bpartial(?=\s+(?:class|interface|struct)\b)/g,	css: 'keyword' },			// contextual keyword: 'partial'
+			{ regex: /\byield(?=\s+(?:return|break)\b)/g,				css: 'keyword' }			// contextual keyword: 'yield'
+			];
+		
+		this.forHtmlScript(SyntaxHighlighter.regexLib.aspScriptTags);
+	};
+
+	Brush.prototype	= new SyntaxHighlighter.Highlighter();
+	Brush.aliases	= ['f#', 'f-sharp', 'fsharp'];
+
+	SyntaxHighlighter.brushes.FSharp = Brush;
+
+	// CommonJS
+	typeof(exports) != 'undefined' ? exports.Brush = Brush : null;
+})();
+


### PR DESCRIPTION
Adds F# support for the syntax highlighter.  This is basically a quick tweak of the C# brush to add more keywords.
