### PR TITLE
Added Swift brush, change for standards-compliance

### DIFF
--- a/sass/apple-swift.scss
+++ b/sass/apple-swift.scss
@@ -1,0 +1,58 @@
+/* apple-swift.css
+ * Emulates Apple Swift documentation syntax highlighting
+ * Contributed by Nate Cook
+ * http://natecook.com/code/swift-brush-for-syntaxhighlighter  */
+ 
+$gutter_text                  : rgba(128,128,128,1) !default;
+$gutter_border                : none !default;
+
+$line_highlighted_background  : #e9e9e9 !default;
+$line_highlighted_number      : white !default;
+			
+$code_comments                : rgba(0,131,18,1) !default;
+$code_string                  : rgba(196, 26, 22, 1) !default;
+$code_keyword                 : rgba(184,51,161,1) !default;
+$code_variable                : rgba(80,129,135,1) !default;
+$code_value                   : rgba(28,0,207,1) !default;
+$code_color1                  : rgba(184,51,161,1) !default;
+$code_color2                  : rgba(111, 65, 167, 1) !default;
+			
+$caption_color                : rgba(53, 53, 53, 1) !default;
+
+@import "_template.scss";
+
+.syntaxhighlighter {
+  a,
+  div,
+  code,
+  table,
+  table td,
+  table tr,
+  table tbody,
+  table thead,
+  table caption,
+  textarea {
+    font: {
+      family: Menlo, Consolas, monospace !important;
+    }
+  }
+  font-size: 0.75em !important; 
+    table td.gutter .line {
+      text-align: right !important;
+      padding: 0.2em 0.5em !important; 
+    }
+    table td.code .line {
+      padding: 0.2em 1em !important;
+    }
+    table td.code .container textarea {
+      padding-top: 0.1em !important;
+      line-height: 1.48em !important;
+    }
+    .gutter .line {
+      background: #f9f9f9 !important;
+      &.highlighted {
+        background-color: #898989 !important;
+        color: white !important;
+      }
+    }
+}

--- a/src/brushes/swift.js
+++ b/src/brushes/swift.js
@@ -6,7 +6,7 @@
 	function Brush()
 	{
 		// Swift brush contributed by Nate Cook
-		// http://natecook.com/code/swift-brush-for-syntaxhighlighter
+		// http://natecook.com/code/swift-syntax-highlighting
 		
 		function getKeywordsPrependedBy(keywords, by)
 		{
@@ -80,9 +80,6 @@
 		};
 		
 		// "Swift-native types" are all the protocols, classes, structs, enums, funcs, vars, and typealiases built into the language
-		// generated this list by saving all the definitions out to "swift-lang.txt"
-		// then running this at the command line:
-		// grep -E "^(protocol|class|struct|enum|func|var|typealias) [a-zA-Z]" swift-lang.txt | sed -E 's/(^[a-z]+) ([a-zA-Z0-9]+).+/\2/g' | sort | uniq | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g'
 		var swiftTypes = 'AbsoluteValuable Any AnyClass Array ArrayBound ArrayBuffer ArrayBufferType ArrayLiteralConvertible ArrayType AutoreleasingUnsafePointer BidirectionalIndex Bit BitwiseOperations Bool C CBool CChar CChar16 CChar32 CConstPointer CConstVoidPointer CDouble CFloat CInt CLong CLongLong CMutablePointer CMutableVoidPointer COpaquePointer CShort CSignedChar CString CUnsignedChar CUnsignedInt CUnsignedLong CUnsignedLongLong CUnsignedShort CVaListPointer CVarArg CWideChar Character CharacterLiteralConvertible Collection CollectionOfOne Comparable ContiguousArray ContiguousArrayBuffer DebugPrintable Dictionary DictionaryGenerator DictionaryIndex DictionaryLiteralConvertible Double EmptyCollection EmptyGenerator EnumerateGenerator Equatable ExtendedGraphemeClusterLiteralConvertible ExtendedGraphemeClusterType ExtensibleCollection FilterCollectionView FilterCollectionViewIndex FilterGenerator FilterSequenceView Float Float32 Float64 Float80 FloatLiteralConvertible FloatLiteralType FloatingPointClassification FloatingPointNumber ForwardIndex Generator GeneratorOf GeneratorOfOne GeneratorSequence Hashable HeapBuffer HeapBufferStorage HeapBufferStorageBase ImplicitlyUnwrappedOptional IndexingGenerator Int Int16 Int32 Int64 Int8 IntEncoder IntMax Integer IntegerArithmetic IntegerLiteralConvertible IntegerLiteralType Less LifetimeManager LogicValue MapCollectionView MapSequenceGenerator MapSequenceView MaxBuiltinFloatType MaxBuiltinIntegerType Mirror MirrorDisposition MutableCollection MutableSliceable ObjectIdentifier OnHeap Optional OutputStream PermutationGenerator Printable QuickLookObject RandomAccessIndex Range RangeGenerator RawByte RawOptionSet RawRepresentable Reflectable Repeat ReverseIndex ReverseRange ReverseRangeGenerator ReverseView Sequence SequenceOf SignedInteger SignedNumber Sink SinkOf Slice SliceBuffer Sliceable StaticString Streamable StridedRangeGenerator String StringElement StringInterpolationConvertible StringLiteralConvertible StringLiteralType UInt UInt16 UInt32 UInt64 UInt8 UIntMax UTF16 UTF32 UTF8 UWord UnicodeCodec UnicodeScalar Unmanaged UnsafeArray UnsafePointer UnsignedInteger Void Word Zip2 ZipGenerator2 abs advance alignof alignofValue assert bridgeFromObjectiveC bridgeFromObjectiveCUnconditional bridgeToObjectiveC bridgeToObjectiveCUnconditional c contains count countElements countLeadingZeros debugPrint debugPrintln distance dropFirst dropLast dump encodeBitsAsWords enumerate equal false filter find getBridgedObjectiveCType getVaList indices insertionSort isBridgedToObjectiveC isBridgedVerbatimToObjectiveC isUniquelyReferenced join lexicographicalCompare map max maxElement min minElement nil numericCast partition posix print println quickSort reduce reflect reinterpretCast reverse roundUpToAlignment sizeof sizeofValue sort split startsWith strideof strideofValue swap swift toString transcode true underestimateCount unsafeReflect withExtendedLifetime withObjectAtPlusZero withUnsafePointer withUnsafePointerToObject withUnsafePointers withVaList';
 		
 		var keywords =	'as break case class continue default deinit do dynamicType else enum ' +
@@ -103,10 +100,6 @@
 			// multiline comments
 			{ regex: new RegExp('\\/\\*[\\s\\S]*\\*\\/', 'g'), css: 'comments', func: multiLineCCommentsAdd },
 			// strings
-			// attempts at 
-			// "([^\\"\n]|\\.)*?("|\\\() -- only collects up to interpolation
-			// ("|\))([^\\"\n]|\\.)*?("|\\\() -- not quite, collects by mistake
-			
 			{ regex: SyntaxHighlighter.regexLib.doubleQuotedString, css: 'string', func: stringAdd },
 			// numbers (decimal, hex, binary, octal)
 			{ regex: new RegExp('\\b([\\d_]+(\\.[\\de_]+)?|0x[a-f0-9_]+(\\.[a-f0-9p_]+)?|0b[01_]+|0o[0-7_]+)\\b', 'gi'), css: 'value' },

--- a/src/brushes/swift.js
+++ b/src/brushes/swift.js
@@ -1,0 +1,135 @@
+;(function()
+{
+	// CommonJS
+	SyntaxHighlighter = SyntaxHighlighter || (typeof require !== 'undefined'? require('shCore').SyntaxHighlighter : null);
+
+	function Brush()
+	{
+		// Swift brush contributed by Nate Cook
+		// http://natecook.com/code/swift-brush-for-syntaxhighlighter
+		
+		function getKeywordsPrependedBy(keywords, by)
+		{
+			return '(?:' + keywords.replace(/^\s+|\s+$/g, '').replace(/\s+/g, '|' + by + '\\b').replace(/^/, by + '\\b') + ')\\b';
+		}
+		
+		function multiLineCCommentsAdd(match, regexInfo) 
+		{
+			var str = match[0], result = [], pos = 0, matchStart = 0, level = 0;
+			
+			while (pos < str.length - 1) {
+				var chunk = str.substr(pos, 2);
+				if (level == 0) {
+					if (chunk == "/*") {
+						matchStart = pos;
+						level++;
+						pos += 2;
+					} else {
+						pos++;
+					}
+				} else {
+					if (chunk == "/*") {
+						level++;
+						pos += 2;
+					} else if (chunk == "*/") {
+						level--;
+						if (level == 0) {
+							result.push(new SyntaxHighlighter.Match(str.substring(matchStart, pos + 2), matchStart + match.index, regexInfo.css));
+						}
+						pos += 2;
+					} else {
+						pos++;					
+					}
+				}
+			}
+			
+			return result;
+		}
+		
+		function stringAdd(match, regexInfo)
+		{
+			var str = match[0], result = [], pos = 0, matchStart = 0, level = 0;
+			
+			while (pos < str.length - 1) {
+				if (level == 0) {
+					if (str.substr(pos, 2) == "\\(") {
+						result.push(new SyntaxHighlighter.Match(str.substring(matchStart, pos + 2), matchStart + match.index, regexInfo.css));
+						level++;
+						pos += 2;
+					} else {
+						pos++;
+					}
+				} else {
+					if (str[pos] == "(") {
+						level++;
+					}
+					if (str[pos] == ")") {
+						level--;
+						if (level == 0) {
+							matchStart = pos;
+						}
+					}
+					pos++;
+				}
+			}
+			if (level == 0) {
+				result.push(new SyntaxHighlighter.Match(str.substring(matchStart, str.length), matchStart + match.index, regexInfo.css));
+			}
+			
+			return result;
+		};
+		
+		// "Swift-native types" are all the protocols, classes, structs, enums, funcs, vars, and typealiases built into the language
+		// generated this list by saving all the definitions out to "swift-lang.txt"
+		// then running this at the command line:
+		// grep -E "^(protocol|class|struct|enum|func|var|typealias) [a-zA-Z]" swift-lang.txt | sed -E 's/(^[a-z]+) ([a-zA-Z0-9]+).+/\2/g' | sort | uniq | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g'
+		var swiftTypes = 'AbsoluteValuable Any AnyClass Array ArrayBound ArrayBuffer ArrayBufferType ArrayLiteralConvertible ArrayType AutoreleasingUnsafePointer BidirectionalIndex Bit BitwiseOperations Bool C CBool CChar CChar16 CChar32 CConstPointer CConstVoidPointer CDouble CFloat CInt CLong CLongLong CMutablePointer CMutableVoidPointer COpaquePointer CShort CSignedChar CString CUnsignedChar CUnsignedInt CUnsignedLong CUnsignedLongLong CUnsignedShort CVaListPointer CVarArg CWideChar Character CharacterLiteralConvertible Collection CollectionOfOne Comparable ContiguousArray ContiguousArrayBuffer DebugPrintable Dictionary DictionaryGenerator DictionaryIndex DictionaryLiteralConvertible Double EmptyCollection EmptyGenerator EnumerateGenerator Equatable ExtendedGraphemeClusterLiteralConvertible ExtendedGraphemeClusterType ExtensibleCollection FilterCollectionView FilterCollectionViewIndex FilterGenerator FilterSequenceView Float Float32 Float64 Float80 FloatLiteralConvertible FloatLiteralType FloatingPointClassification FloatingPointNumber ForwardIndex Generator GeneratorOf GeneratorOfOne GeneratorSequence Hashable HeapBuffer HeapBufferStorage HeapBufferStorageBase ImplicitlyUnwrappedOptional IndexingGenerator Int Int16 Int32 Int64 Int8 IntEncoder IntMax Integer IntegerArithmetic IntegerLiteralConvertible IntegerLiteralType Less LifetimeManager LogicValue MapCollectionView MapSequenceGenerator MapSequenceView MaxBuiltinFloatType MaxBuiltinIntegerType Mirror MirrorDisposition MutableCollection MutableSliceable ObjectIdentifier OnHeap Optional OutputStream PermutationGenerator Printable QuickLookObject RandomAccessIndex Range RangeGenerator RawByte RawOptionSet RawRepresentable Reflectable Repeat ReverseIndex ReverseRange ReverseRangeGenerator ReverseView Sequence SequenceOf SignedInteger SignedNumber Sink SinkOf Slice SliceBuffer Sliceable StaticString Streamable StridedRangeGenerator String StringElement StringInterpolationConvertible StringLiteralConvertible StringLiteralType UInt UInt16 UInt32 UInt64 UInt8 UIntMax UTF16 UTF32 UTF8 UWord UnicodeCodec UnicodeScalar Unmanaged UnsafeArray UnsafePointer UnsignedInteger Void Word Zip2 ZipGenerator2 abs advance alignof alignofValue assert bridgeFromObjectiveC bridgeFromObjectiveCUnconditional bridgeToObjectiveC bridgeToObjectiveCUnconditional c contains count countElements countLeadingZeros debugPrint debugPrintln distance dropFirst dropLast dump encodeBitsAsWords enumerate equal false filter find getBridgedObjectiveCType getVaList indices insertionSort isBridgedToObjectiveC isBridgedVerbatimToObjectiveC isUniquelyReferenced join lexicographicalCompare map max maxElement min minElement nil numericCast partition posix print println quickSort reduce reflect reinterpretCast reverse roundUpToAlignment sizeof sizeofValue sort split startsWith strideof strideofValue swap swift toString transcode true underestimateCount unsafeReflect withExtendedLifetime withObjectAtPlusZero withUnsafePointer withUnsafePointerToObject withUnsafePointers withVaList';
+		
+		var keywords =	'as break case class continue default deinit do dynamicType else enum ' +
+						'extension fallthrough for func if import in init is let new protocol ' + 
+						'return self Self static struct subscript super switch Type typealias ' +
+						'var where while __COLUMN__ __FILE__ __FUNCTION__ __LINE__ associativity ' +
+						'didSet get infix inout left mutating none nonmutating operator override ' +
+						'postfix precedence prefix right set unowned unowned(safe) unowned(unsafe) weak willSet';		
+		
+		var attributes = 'assignment class_protocol exported final lazy noreturn NSCopying NSManaged objc optional required auto_closure noreturn IBAction IBDesignable IBInspectable IBOutlet infix prefix postfix';
+		
+		
+		this.regexList = [
+			// html entities
+			{ regex: new RegExp('\&[a-z]+;', 'gi'),	css: 'plain' },
+			// one line comments
+			{ regex: SyntaxHighlighter.regexLib.singleLineCComments, css: 'comments' },
+			// multiline comments
+			{ regex: new RegExp('\\/\\*[\\s\\S]*\\*\\/', 'g'), css: 'comments', func: multiLineCCommentsAdd },
+			// strings
+			// attempts at 
+			// "([^\\"\n]|\\.)*?("|\\\() -- only collects up to interpolation
+			// ("|\))([^\\"\n]|\\.)*?("|\\\() -- not quite, collects by mistake
+			
+			{ regex: SyntaxHighlighter.regexLib.doubleQuotedString, css: 'string', func: stringAdd },
+			// numbers (decimal, hex, binary, octal)
+			{ regex: new RegExp('\\b([\\d_]+(\\.[\\de_]+)?|0x[a-f0-9_]+(\\.[a-f0-9p_]+)?|0b[01_]+|0o[0-7_]+)\\b', 'gi'), css: 'value' },
+			// Swift keywords
+			{ regex: new RegExp(this.getKeywords(keywords), 'gm'), css: 'keyword' },
+			// Swift @attributes	
+			{ regex: new RegExp(getKeywordsPrependedBy(attributes, '@'), 'gm'), css: 'color1' },
+			// Swift-native types
+			{ regex: new RegExp(this.getKeywords(swiftTypes), 'gm'), css: 'color2' },
+			// user-defined variables, functions, etc.
+			{ regex: new RegExp('\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b', 'gi'), css: 'variable' },
+			];
+	};
+
+	Brush.prototype	= new SyntaxHighlighter.Highlighter();
+	Brush.aliases	= ['swift'];
+
+	SyntaxHighlighter.brushes.Swift = Brush;
+
+	// CommonJS
+	typeof(exports) != 'undefined' ? exports.Brush = Brush : null;
+})();
+
+
+
+

--- a/src/config.js
+++ b/src/config.js
@@ -10,5 +10,9 @@ module.exports = {
   stripBrs: false,
 
   /** Name of the tag that SyntaxHighlighter will automatically look for. */
-  tagName: 'pre'
+  tagName: 'pre',
+
+  /** When set, uses data attribute instead of className for configuration. */
+  useDataAttribute: null
+  // useDataAttribute: 'data-syntaxhighlighter'
 };

--- a/src/core.js
+++ b/src/core.js
@@ -51,10 +51,11 @@ var sh = module.exports = {
 
     for (var i = 0, l = elements.length; i < l; i++)
     {
+      var elOpts = sh.config.useDataAttribute ? elements[i].getAttribute(sh.config.useDataAttribute) : elements[i].className;
       var item = {
         target: elements[i],
         // local params take precedence over globals
-        params: optsParser.defaults(optsParser.parse(elements[i].className), globalParams)
+        params: optsParser.defaults(optsParser.parse(elOpts), globalParams)
       };
 
       if (item.params['brush'] == null)


### PR DESCRIPTION
Adds highlighting support for Swift, Apple's new language for iOS and Mac OS X, along with a theme that follows Apple's newish documentation style.

Also allows configuration to be done with a data-attribute, instead of using the class attribute in a nonstandard way.
