### PR TITLE
Fix typo in ruby brush

### DIFF
--- a/src/js/shBrushRuby.js
+++ b/src/js/shBrushRuby.js
@@ -11,7 +11,7 @@
 						'END end ensure false for if in module new next nil not or raise redo rescue retry return ' +
 						'self super then throw true undef unless until when while yield';
 
-		var builtins =	'Array Bignum Binding Class Continuation Dir Exception FalseClass File::Stat File Fixnum Fload ' +
+		var builtins =	'Array Bignum Binding Class Continuation Dir Exception FalseClass File::Stat File Fixnum Float ' +
 						'Hash Integer IO MatchData Method Module NilClass Numeric Object Proc Range Regexp String Struct::TMS Symbol ' +
 						'ThreadGroup Thread Time TrueClass';
 


### PR DESCRIPTION
`Float` instead of `Fload`
