### PR TITLE
Fix to prevent negative substring end index.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -241,7 +241,7 @@ function stripCData(original)
 
   var copyLength = copy.length;
 
-  if (copy.indexOf(right) == copyLength - rightLength)
+  if ((copyLength >= rightLength) && (copy.indexOf(right) == copyLength - rightLength))
   {
     copy = copy.substring(0, copyLength - rightLength);
     changed = true;


### PR DESCRIPTION
This will prevent short strings from being wiped out.

Related: https://github.com/metacpan/metacpan-web/issues/1228